### PR TITLE
fix toolpage redirect

### DIFF
--- a/toolsWebsite/tools/views.py
+++ b/toolsWebsite/tools/views.py
@@ -83,7 +83,7 @@ def edit_tool(request, tool_id):
     t.price = request.POST['price']
     t.tool_image = request.POST['img']
     t.save()
-    return redirect('index')
+    return redirect('toolpage', tool_id)
 
 
 def checkedOut(request):


### PR DESCRIPTION
Make sure after editing a tool you go back to the `toolpage` and not the home screen